### PR TITLE
� HOTFIX: Fix authenticateToken import error in logout route

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -187,7 +187,7 @@ router.post('/login', login);
  * @desc    Logout user
  * @access  Public
  */
-router.post('/logout', authenticateToken, logout);
+router.post('/logout', requireAuth, logout);
 
 /**
  * @swagger


### PR DESCRIPTION
✅ CRITICAL FIX:
- Replace undefined authenticateToken with requireAuth middleware
- Fix ReferenceError that was preventing server startup
- Logout route now uses correct authentication middleware

� RESOLVES:
- ReferenceError: authenticateToken is not defined
- Server startup failure in production
- Logout audit logging functionality restored

� IMMEDIATE DEPLOYMENT NEEDED